### PR TITLE
Add frontmatter to bug_report

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,16 +1,26 @@
+---
+name: Bug Report
+about: Report a bug to help us improve the project
+title: "[BUG] <short description>"
+labels: bug
+type: "Bug"
+assignees: ""
+---
+
 <!--
-Welcome! 
+Welcome!
 To expedite issue processing please search open and closed issues before submitting a new one.
 Existing issues often contain information about workarounds, resolution, or progress updates.
 -->
+
 ## Version
 
 What release version was the issue found in?
 
 ## Hardware configuration
 
-List Hardware components used. 
-Ex. 
+List Hardware components used.
+Ex.
 Issue found with the following:
 - Intel® xeon Platinum 8351N with Intel® Data Center GPU Flex 140
 - 12th Gen Intel® Core™ i7 with Intel® Arc™ A770M Graphics


### PR DESCRIPTION
## PR Checklist
<!-- Please check if your PR fulfills the following requirements: -->

- [ ] Added label to the Pull Request for easier discoverability and search
- [ ] Commit Message meets guidelines as indicated in the URL https://github.com/intel-retail/loss-prevention/blob/main/CONTRIBUTING.md
- [ ] Every commit is a single defect fix and does not mix feature addition or changes
- [ ] Unit Tests have been added for new changes
- [ ] Updated Documentation as relevant to the changes
- [ ] All commented code has been removed
- [ ] If you've added a dependency, you've ensured license is compatible with repository license and clearly outlined the added dependency.
- [ ] PR change contains code related to security
- [ ] PR introduces changes that breaks compatibility with other modules (If YES, please provide details below)

## What are you changing?
The bug_report template in the loss-prevention repository wasn't working due to missing frontmatter - I've fixed this in this PR. Going forward, each bug report will automatically have the "bug" type and label assigned for easier tracking and statistics.

## Issue this PR will close

close: #**issue_number**

## Anything the reviewer should know when reviewing this PR?

## Test Instructions if applicable
<!-- How can the reviewers test your change? -->

## If the there are associated PRs in other repositories, please link them here (i.e. intel-retail/loss-prevention )
