### PR TITLE
fix(enhancement): Added target fps key in camera config

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,19 +87,7 @@ Push item-recognition accuracy beyond traditional CV with a **local Large Vision
 ## How to think about performance & stream density
 The metrics that matter: **FPS, end-to-end latency, CPU/GPU/NPU utilization, power, and stream density** (for GenAI/LVLM use cases also **TTFT** and **token throughput**).
 
-- **Stream density = the most concurrent streams a box sustains at a target FPS.** Because an LP lane is **multi-camera** (six cameras at potentially different frame-rate needs), density is best read as **use-case instances** — “how many shopping lanes with this use case running per box” — judging **each camera against its own FPS target** (use-case density, not a raw stream count).
-- **Implementation scope note:** the stream-density behaviors below are implemented in the `performance-tools` submodule (`benchmark-scripts/stream_density.py`). This repo provides the camera config JSON inputs (including `targetFps`) used by that logic.
-- **Per-camera target FPS (`targetFps`) support (optional key):** in `camera_to_workload_*.json`, you can add `lane_config.cameras[].targetFps` per camera when you want per-stream targets. If you remove this key (or set it to an invalid/non-positive value), stream density falls back to global `TARGET_FPS`.
-- **Why this value matters:** `targetFps` is the expected sustained per-camera processing rate used to decide stream pass/fail and density scaling. Lower values generally allow higher stream density (more concurrent streams), while higher values demand more compute per stream and can reduce density. Set it based on workload criticality and source FPS.
-- **Per-stream pass/fail comparison:** pass/fail is evaluated per stream (not one global threshold):
-  - pass threshold = `stream_target_fps * PASS_TOLERANCE_RATIO`
-  - fail threshold = `pass threshold - HYSTERESIS_FPS`
-- **Increment behavior:**
-  - If `PIPELINE_INC` is provided, that hint is used.
-  - Otherwise, increments are estimated from observed per-stream FPS and the **mean** target FPS across streams, then adjusted conservatively by the benchmark logic.
-- **Debug key for visibility:** set `STREAM_DENSITY_DEBUG=1` to print the per-stream target map, pass/fail thresholds, passing/failing streams, and mean target FPS used by increment estimation.
-- **Camera config cache behavior:** stream-density caches parsed camera-target mappings using `(config_path, file_mtime)`. This avoids re-parsing the JSON every iteration and automatically refreshes when the file changes.
-- **Test coverage location:** stream-density unit tests for this behavior are in the `performance-tools` repo (`benchmark-scripts/stream_density_test.py`), including mixed `targetFps` values and missing camera-config fallback scenarios.
+-  **Stream density = the most concurrent streams a box sustains at a target FPS.** Because an LP lane is **multi-camera** (six cameras at potentially different frame-rate needs), density is best read as **use-case instances**f — “how many shopping lanes with this use case running per box” — judging **each camera against its own FPS target** (use-case density, not a raw stream count).
 - **Reading the result:** a stream cannot sustain more than its source FPS — any per-stream reading **above** the source rate is a measurement artifact (catch-up burst), not real throughput.
 - **How we measure it:** we ramp the number of streams, let each step settle, then read the sustained per-stream FPS against the target to find the most streams that hold it. This method has **known limitations** (a short measurement window can misread under noise) and we’re **actively improving it** toward a more robust steady-state measurement. ⚙️ *engineering: align on the final method.*
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ Push item-recognition accuracy beyond traditional CV with a **local Large Vision
 The metrics that matter: **FPS, end-to-end latency, CPU/GPU/NPU utilization, power, and stream density** (for GenAI/LVLM use cases also **TTFT** and **token throughput**).
 
 - **Stream density = the most concurrent streams a box sustains at a target FPS.** Because an LP lane is **multi-camera** (six cameras at potentially different frame-rate needs), density is best read as **use-case instances** — “how many shopping lanes with this use case running per box” — judging **each camera against its own FPS target** (use-case density, not a raw stream count).
-- **Per-camera target FPS (`targetFps`) support:** camera config JSON can now define `lane_config.cameras[].targetFps` in `camera_to_workload_*.json`. During density runs, each pipeline stream gets its target from this key; if missing, invalid, or non-positive, it falls back to `TARGET_FPS`.
+- **Implementation scope note:** the stream-density behaviors below are implemented in the `performance-tools` submodule (`benchmark-scripts/stream_density.py`). This repo provides the camera config JSON inputs (including `targetFps`) used by that logic.
+- **Per-camera target FPS (`targetFps`) support:** camera config JSON can define `lane_config.cameras[].targetFps` in `camera_to_workload_*.json`. During density runs, each pipeline stream gets its target from this key; if missing, invalid, or non-positive, it falls back to `TARGET_FPS`.
 - **Per-stream pass/fail comparison:** pass/fail is evaluated per stream (not one global threshold):
   - pass threshold = `stream_target_fps * PASS_TOLERANCE_RATIO`
   - fail threshold = `pass threshold - HYSTERESIS_FPS`
@@ -97,7 +98,7 @@ The metrics that matter: **FPS, end-to-end latency, CPU/GPU/NPU utilization, pow
   - Otherwise, increments are estimated from observed per-stream FPS and the **mean** target FPS across streams, then adjusted conservatively by the benchmark logic.
 - **Debug key for visibility:** set `STREAM_DENSITY_DEBUG=1` to print the per-stream target map, pass/fail thresholds, passing/failing streams, and mean target FPS used by increment estimation.
 - **Camera config cache behavior:** stream-density caches parsed camera-target mappings using `(config_path, file_mtime)`. This avoids re-parsing the JSON every iteration and automatically refreshes when the file changes.
-- **Test coverage added for this behavior:** stream-density unit tests include cases for mixed `targetFps` values (`numeric`, `string numeric`, `0`, negative, invalid text) and missing camera config path fallback to default target FPS for all streams.
+- **Test coverage location:** stream-density unit tests for this behavior are in the `performance-tools` repo (`benchmark-scripts/stream_density_test.py`), including mixed `targetFps` values and missing camera-config fallback scenarios.
 - **Reading the result:** a stream cannot sustain more than its source FPS — any per-stream reading **above** the source rate is a measurement artifact (catch-up burst), not real throughput.
 - **How we measure it:** we ramp the number of streams, let each step settle, then read the sustained per-stream FPS against the target to find the most streams that hold it. This method has **known limitations** (a short measurement window can misread under noise) and we’re **actively improving it** toward a more robust steady-state measurement. ⚙️ *engineering: align on the final method.*
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,8 @@ The metrics that matter: **FPS, end-to-end latency, CPU/GPU/NPU utilization, pow
 
 - **Stream density = the most concurrent streams a box sustains at a target FPS.** Because an LP lane is **multi-camera** (six cameras at potentially different frame-rate needs), density is best read as **use-case instances** — “how many shopping lanes with this use case running per box” — judging **each camera against its own FPS target** (use-case density, not a raw stream count).
 - **Implementation scope note:** the stream-density behaviors below are implemented in the `performance-tools` submodule (`benchmark-scripts/stream_density.py`). This repo provides the camera config JSON inputs (including `targetFps`) used by that logic.
-- **Per-camera target FPS (`targetFps`) support:** camera config JSON can define `lane_config.cameras[].targetFps` in `camera_to_workload_*.json`. During density runs, each pipeline stream gets its target from this key; if missing, invalid, or non-positive, it falls back to `TARGET_FPS`.
+- **Per-camera target FPS (`targetFps`) support (optional key):** in `camera_to_workload_*.json`, you can add `lane_config.cameras[].targetFps` per camera when you want per-stream targets. If you remove this key (or set it to an invalid/non-positive value), stream density falls back to global `TARGET_FPS`.
+- **Why this value matters:** `targetFps` is the expected sustained per-camera processing rate used to decide stream pass/fail and density scaling. Lower values generally allow higher stream density (more concurrent streams), while higher values demand more compute per stream and can reduce density. Set it based on workload criticality and source FPS.
 - **Per-stream pass/fail comparison:** pass/fail is evaluated per stream (not one global threshold):
   - pass threshold = `stream_target_fps * PASS_TOLERANCE_RATIO`
   - fail threshold = `pass threshold - HYSTERESIS_FPS`

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Push item-recognition accuracy beyond traditional CV with a **local Large Vision
 ## How to think about performance & stream density
 The metrics that matter: **FPS, end-to-end latency, CPU/GPU/NPU utilization, power, and stream density** (for GenAI/LVLM use cases also **TTFT** and **token throughput**).
 
--  **Stream density = the most concurrent streams a box sustains at a target FPS.** Because an LP lane is **multi-camera** (six cameras at potentially different frame-rate needs), density is best read as **use-case instances**f — “how many shopping lanes with this use case running per box” — judging **each camera against its own FPS target** (use-case density, not a raw stream count).
+- **Stream density = the most concurrent streams a box sustains at a target FPS.** Because an LP lane is **multi-camera** (six cameras at potentially different frame-rate needs), density is best read as **use-case instances**f — “how many shopping lanes with this use case running per box” — judging **each camera against its own FPS target** (use-case density, not a raw stream count).
 - **Reading the result:** a stream cannot sustain more than its source FPS — any per-stream reading **above** the source rate is a measurement artifact (catch-up burst), not real throughput.
 - **How we measure it:** we ramp the number of streams, let each step settle, then read the sustained per-stream FPS against the target to find the most streams that hold it. This method has **known limitations** (a short measurement window can misread under noise) and we’re **actively improving it** toward a more robust steady-state measurement. ⚙️ *engineering: align on the final method.*
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,17 @@ Push item-recognition accuracy beyond traditional CV with a **local Large Vision
 ## How to think about performance & stream density
 The metrics that matter: **FPS, end-to-end latency, CPU/GPU/NPU utilization, power, and stream density** (for GenAI/LVLM use cases also **TTFT** and **token throughput**).
 
-- **Stream density = the most concurrent streams a box sustains at a target FPS.** Because an LP lane is **multi-camera** (six cameras at potentially different frame-rate needs), density is best read as **use-case instances**f — “how many shopping lanes with this use case running per box” — judging **each camera against its own FPS target** (use-case density, not a raw stream count).
+- **Stream density = the most concurrent streams a box sustains at a target FPS.** Because an LP lane is **multi-camera** (six cameras at potentially different frame-rate needs), density is best read as **use-case instances** — “how many shopping lanes with this use case running per box” — judging **each camera against its own FPS target** (use-case density, not a raw stream count).
+- **Per-camera target FPS (`targetFps`) support:** camera config JSON can now define `lane_config.cameras[].targetFps` in `camera_to_workload_*.json`. During density runs, each pipeline stream gets its target from this key; if missing, invalid, or non-positive, it falls back to `TARGET_FPS`.
+- **Per-stream pass/fail comparison:** pass/fail is evaluated per stream (not one global threshold):
+  - pass threshold = `stream_target_fps * PASS_TOLERANCE_RATIO`
+  - fail threshold = `pass threshold - HYSTERESIS_FPS`
+- **Increment behavior:**
+  - If `PIPELINE_INC` is provided, that hint is used.
+  - Otherwise, increments are estimated from observed per-stream FPS and the **mean** target FPS across streams, then adjusted conservatively by the benchmark logic.
+- **Debug key for visibility:** set `STREAM_DENSITY_DEBUG=1` to print the per-stream target map, pass/fail thresholds, passing/failing streams, and mean target FPS used by increment estimation.
+- **Camera config cache behavior:** stream-density caches parsed camera-target mappings using `(config_path, file_mtime)`. This avoids re-parsing the JSON every iteration and automatically refreshes when the file changes.
+- **Test coverage added for this behavior:** stream-density unit tests include cases for mixed `targetFps` values (`numeric`, `string numeric`, `0`, negative, invalid text) and missing camera config path fallback to default target FPS for all streams.
 - **Reading the result:** a stream cannot sustain more than its source FPS — any per-stream reading **above** the source rate is a measurement artifact (catch-up burst), not real throughput.
 - **How we measure it:** we ramp the number of streams, let each step settle, then read the sustained per-stream FPS against the target to find the most streams that hold it. This method has **known limitations** (a short measurement window can misread under noise) and we’re **actively improving it** toward a more robust steady-state measurement. ⚙️ *engineering: align on the final method.*
 

--- a/configs/camera_to_workload.json
+++ b/configs/camera_to_workload.json
@@ -1,9 +1,10 @@
 {
   "lane_config": {
-    "cameras": [  
-      { 
+    "cameras": [
+      {
         "camera_id": "cam1",
         "fps": 15,
+        "targetFps": 7,
         "width": 1080,
         "height": 1920,
         "fileSrc":"items-in-basket-32658421.mp4|https://www.pexels.com/download/video/32658421", 
@@ -15,9 +16,10 @@
           "y2": 1340
         }
       },
-      { 
-        "camera_id": "cam2", 
-         "fps": 15,
+      {
+        "camera_id": "cam2",
+        "fps": 15,
+        "targetFps": 11,
         "width": 1080,
         "height": 1920,
         "fileSrc":"hidden-items-product-switching-32658426.mp4|https://www.pexels.com/download/video/32658426", 
@@ -28,12 +30,13 @@
           "x2": 1060,
           "y2": 1340
         }
-      },   
-      { 
-        "camera_id": "cam3", 
+      },
+      {
+        "camera_id": "cam3",
+        "fps": 15,
+        "targetFps": 9,
         "width": 1920,
         "height": 1080,
-        "fps": 15,
         "fileSrc":"fake-scan-detection-32658425.mp4|https://www.pexels.com/download/video/32658425", 
         "workloads": ["fake_scan_detection"],
         "region_of_interest": {
@@ -43,9 +46,10 @@
           "y2": 1085
         }
       },
-      { 
+      {
         "camera_id": "cam4",
         "fps": 15,
+        "targetFps": 13,
         "width": 1080,
         "height": 1920,
         "fileSrc":"items-in-basket-32658421.mp4|https://www.pexels.com/download/video/32658421", 
@@ -57,9 +61,10 @@
           "y2": 1340
         }
       },
-      { 
-        "camera_id": "cam5", 
-         "fps": 15,
+      {
+        "camera_id": "cam5",
+        "fps": 15,
+        "targetFps": 8,
         "width": 1080,
         "height": 1920,
         "fileSrc":"hidden-items-product-switching-32658426.mp4|https://www.pexels.com/download/video/32658426", 
@@ -71,9 +76,10 @@
           "y2": 1340
         }
       },
-      { 
-        "camera_id": "cam6", 
-         "fps": 15,
+      {
+        "camera_id": "cam6",
+        "fps": 15,
+        "targetFps": 10,
         "width": 1080,
         "height": 1920,
         "fileSrc":"face-detection-3249935.mp4|https://www.pexels.com/download/video/3249935", 

--- a/configs/camera_to_workload.json
+++ b/configs/camera_to_workload.json
@@ -1,10 +1,12 @@
 {
+  "_notes": {
+    "targetFps": "Optional per-camera key. Add lane_config.cameras[].targetFps to set per-stream target FPS. If omitted, stream density falls back to global TARGET_FPS."
+  },
   "lane_config": {
     "cameras": [
       {
         "camera_id": "cam1",
         "fps": 15,
-        "targetFps": 7,
         "width": 1080,
         "height": 1920,
         "fileSrc":"items-in-basket-32658421.mp4|https://www.pexels.com/download/video/32658421", 
@@ -19,7 +21,6 @@
       {
         "camera_id": "cam2",
         "fps": 15,
-        "targetFps": 11,
         "width": 1080,
         "height": 1920,
         "fileSrc":"hidden-items-product-switching-32658426.mp4|https://www.pexels.com/download/video/32658426", 
@@ -34,7 +35,6 @@
       {
         "camera_id": "cam3",
         "fps": 15,
-        "targetFps": 9,
         "width": 1920,
         "height": 1080,
         "fileSrc":"fake-scan-detection-32658425.mp4|https://www.pexels.com/download/video/32658425", 
@@ -49,7 +49,6 @@
       {
         "camera_id": "cam4",
         "fps": 15,
-        "targetFps": 13,
         "width": 1080,
         "height": 1920,
         "fileSrc":"items-in-basket-32658421.mp4|https://www.pexels.com/download/video/32658421", 
@@ -64,7 +63,6 @@
       {
         "camera_id": "cam5",
         "fps": 15,
-        "targetFps": 8,
         "width": 1080,
         "height": 1920,
         "fileSrc":"hidden-items-product-switching-32658426.mp4|https://www.pexels.com/download/video/32658426", 
@@ -79,7 +77,6 @@
       {
         "camera_id": "cam6",
         "fps": 15,
-        "targetFps": 10,
         "width": 1080,
         "height": 1920,
         "fileSrc":"face-detection-3249935.mp4|https://www.pexels.com/download/video/3249935", 

--- a/configs/camera_to_workload_asc_age_verification.json
+++ b/configs/camera_to_workload_asc_age_verification.json
@@ -1,10 +1,12 @@
 {
+  "_notes": {
+    "targetFps": "Optional per-camera key. Add lane_config.cameras[].targetFps to set per-stream target FPS. If omitted, stream density falls back to global TARGET_FPS."
+  },
   "lane_config": {
     "cameras": [
       {
         "camera_id": "cam1",
         "fps": 15,
-        "targetFps": 7,
         "width": 1080,
         "height": 1920,
         "fileSrc":"age_prediction-1920-15-bench.mp4|https://www.pexels.com/download/video/3249935", 
@@ -13,7 +15,6 @@
       {
         "camera_id": "cam2",
         "fps": 15,
-        "targetFps": 12,
         "width": 1080,
         "height": 1920,
         "fileSrc":"obj_classification-1920-15-bench.mp4|https://www.pexels.com/download/video/6891009", 

--- a/configs/camera_to_workload_asc_age_verification.json
+++ b/configs/camera_to_workload_asc_age_verification.json
@@ -1,17 +1,19 @@
 {
   "lane_config": {
-    "cameras": [  
-      { 
-        "camera_id": "cam1", 
-         "fps": 15,
+    "cameras": [
+      {
+        "camera_id": "cam1",
+        "fps": 15,
+        "targetFps": 7,
         "width": 1080,
         "height": 1920,
         "fileSrc":"age_prediction-1920-15-bench.mp4|https://www.pexels.com/download/video/3249935", 
         "workloads": ["asc_obj_detection_age_prediction_face_detection"]
       },
-      { 
-        "camera_id": "cam2", 
-         "fps": 15,
+      {
+        "camera_id": "cam2",
+        "fps": 15,
+        "targetFps": 12,
         "width": 1080,
         "height": 1920,
         "fileSrc":"obj_classification-1920-15-bench.mp4|https://www.pexels.com/download/video/6891009", 

--- a/configs/camera_to_workload_asc_hetero.json
+++ b/configs/camera_to_workload_asc_hetero.json
@@ -1,10 +1,12 @@
 {
+  "_notes": {
+    "targetFps": "Optional per-camera key. Add lane_config.cameras[].targetFps to set per-stream target FPS. If omitted, stream density falls back to global TARGET_FPS."
+  },
   "lane_config": {
     "cameras": [
       {
         "camera_id": "cam1",
         "fps": 15,
-        "targetFps": 7,
         "width": 1080,
         "height": 1920,
         "fileSrc":"age_prediction-1920-15-bench.mp4|https://www.pexels.com/download/video/3249935", 
@@ -13,7 +15,6 @@
       {
         "camera_id": "cam2",
         "fps": 15,
-        "targetFps": 10,
         "width": 1080,
         "height": 1920,
         "fileSrc":"obj_classification-1920-15-bench.mp4|https://www.pexels.com/download/video/6891009", 
@@ -22,7 +23,6 @@
       {
         "camera_id": "cam3",
         "fps": 15,
-        "targetFps": 11,
         "width": 1080,
         "height": 1920,
         "fileSrc":"obj_classification-1920-15-bench.mp4|https://www.pexels.com/download/video/6891009", 
@@ -31,7 +31,6 @@
       {
         "camera_id": "cam4",
         "fps": 15,
-        "targetFps": 13,
         "width": 1080,
         "height": 1920,
         "fileSrc":"obj_classification-1920-15-bench.mp4|https://www.pexels.com/download/video/6891009", 

--- a/configs/camera_to_workload_asc_hetero.json
+++ b/configs/camera_to_workload_asc_hetero.json
@@ -1,33 +1,37 @@
 {
   "lane_config": {
-    "cameras": [  
-      { 
-        "camera_id": "cam1", 
-         "fps": 15,
+    "cameras": [
+      {
+        "camera_id": "cam1",
+        "fps": 15,
+        "targetFps": 7,
         "width": 1080,
         "height": 1920,
         "fileSrc":"age_prediction-1920-15-bench.mp4|https://www.pexels.com/download/video/3249935", 
         "workloads": ["asc_obj_detection_age_prediction_face_detection"]
       },
-      { 
-        "camera_id": "cam2", 
-         "fps": 15,
+      {
+        "camera_id": "cam2",
+        "fps": 15,
+        "targetFps": 10,
         "width": 1080,
         "height": 1920,
         "fileSrc":"obj_classification-1920-15-bench.mp4|https://www.pexels.com/download/video/6891009", 
         "workloads": ["asc_obj_detection_age_prediction"]
       },
-      { 
-        "camera_id": "cam3", 
-         "fps": 15,
+      {
+        "camera_id": "cam3",
+        "fps": 15,
+        "targetFps": 11,
         "width": 1080,
         "height": 1920,
         "fileSrc":"obj_classification-1920-15-bench.mp4|https://www.pexels.com/download/video/6891009", 
         "workloads": ["asc_object_detection_yolo11n_classification_effnetb0"]
       },
-       { 
-        "camera_id": "cam4", 
-         "fps": 15,
+      {
+        "camera_id": "cam4",
+        "fps": 15,
+        "targetFps": 13,
         "width": 1080,
         "height": 1920,
         "fileSrc":"obj_classification-1920-15-bench.mp4|https://www.pexels.com/download/video/6891009", 

--- a/configs/camera_to_workload_asc_object_detection.json
+++ b/configs/camera_to_workload_asc_object_detection.json
@@ -1,9 +1,10 @@
 {
   "lane_config": {
-    "cameras": [  
-      { 
-        "camera_id": "cam1", 
-         "fps": 15,
+    "cameras": [
+      {
+        "camera_id": "cam1",
+        "fps": 15,
+        "targetFps": 12,
         "width": 1080,
         "height": 1920,
         "fileSrc":"obj_classification-1920-15-bench.mp4|https://www.pexels.com/download/video/6891009", 

--- a/configs/camera_to_workload_asc_object_detection.json
+++ b/configs/camera_to_workload_asc_object_detection.json
@@ -1,10 +1,12 @@
 {
+  "_notes": {
+    "targetFps": "Optional per-camera key. Add lane_config.cameras[].targetFps to set per-stream target FPS. If omitted, stream density falls back to global TARGET_FPS."
+  },
   "lane_config": {
     "cameras": [
       {
         "camera_id": "cam1",
         "fps": 15,
-        "targetFps": 12,
         "width": 1080,
         "height": 1920,
         "fileSrc":"obj_classification-1920-15-bench.mp4|https://www.pexels.com/download/video/6891009", 

--- a/configs/camera_to_workload_asc_object_detection_classification.json
+++ b/configs/camera_to_workload_asc_object_detection_classification.json
@@ -1,9 +1,10 @@
 {
   "lane_config": {
-    "cameras": [        
-      { 
-        "camera_id": "cam1", 
-         "fps": 15,
+    "cameras": [
+      {
+        "camera_id": "cam1",
+        "fps": 15,
+        "targetFps": 9,
         "width": 1920,
         "height": 1080,
         "fileSrc":"obj_classification-1920-15-bench.mp4|https://www.pexels.com/download/video/6891009", 

--- a/configs/camera_to_workload_asc_object_detection_classification.json
+++ b/configs/camera_to_workload_asc_object_detection_classification.json
@@ -1,10 +1,12 @@
 {
+  "_notes": {
+    "targetFps": "Optional per-camera key. Add lane_config.cameras[].targetFps to set per-stream target FPS. If omitted, stream density falls back to global TARGET_FPS."
+  },
   "lane_config": {
     "cameras": [
       {
         "camera_id": "cam1",
         "fps": 15,
-        "targetFps": 9,
         "width": 1920,
         "height": 1080,
         "fileSrc":"obj_classification-1920-15-bench.mp4|https://www.pexels.com/download/video/6891009", 

--- a/configs/camera_to_workload_vlm.json
+++ b/configs/camera_to_workload_vlm.json
@@ -1,9 +1,10 @@
 {
   "lane_config": {
-    "cameras": [     
-      { 
+    "cameras": [
+      {
         "camera_id": "cam1",
         "fps": 15,
+        "targetFps": 15,
         "width": 1080,
         "height": 1920,
         "fileSrc":"lp-vlm.mp4|https://www.pexels.com/download/video/35256160", 

--- a/configs/camera_to_workload_vlm.json
+++ b/configs/camera_to_workload_vlm.json
@@ -1,10 +1,12 @@
 {
+  "_notes": {
+    "targetFps": "Optional per-camera key. Add lane_config.cameras[].targetFps to set per-stream target FPS. If omitted, stream density falls back to global TARGET_FPS."
+  },
   "lane_config": {
     "cameras": [
       {
         "camera_id": "cam1",
         "fps": 15,
-        "targetFps": 15,
         "width": 1080,
         "height": 1920,
         "fileSrc":"lp-vlm.mp4|https://www.pexels.com/download/video/35256160", 


### PR DESCRIPTION
Evaluate stream density per camera target FPS

Resolves:#235

## PR Checklist
<!-- Please check if your PR fulfills the following requirements: -->

- [x] Added label to the Pull Request for easier discoverability and search
- [x] Commit Message meets guidelines as indicated in the URL https://github.com/intel-retail/loss-prevention/blob/main/CONTRIBUTING.md
- [x] Every commit is a single defect fix and does not mix feature addition or changes
- [x] Unit Tests have been added for new changes
- [x] Updated Documentation as relevant to the changes
- [x] All commented code has been removed
- [ ] If you've added a dependency, you've ensured license is compatible with repository license and clearly outlined the added dependency.
- [ ] PR change contains code related to security
- [ ] PR introduces changes that breaks compatibility with other modules (If YES, please provide details below)

## What are you changing?
Added targetFps key for each camera stream, in camera config json

## Issue this PR will close

close: #235 

## Anything the reviewer should know when reviewing this PR?
Per-stream pass/fail thresholds with hysteresis are now used instead of a single shared FPS target, and target FPS thresholds are taken from camera config JSON files.

## Test Instructions if applicable

- Use a camera config with different targetFps values per camera.
- Run stream density benchmark.
- Confirm each stream is checked against its own threshold before stopping.

## If the there are associated PRs in other repositories, please link them here (i.e. intel-retail/loss-prevention )
Need performance tools changes to be merged before merging this PR
LINK: https://github.com/intel-retail/performance-tools/pull/236